### PR TITLE
Issue #1 - Tasks using Pattern matching for finding files now throw a…

### DIFF
--- a/Frends.File.Tests/UnitTest.cs
+++ b/Frends.File.Tests/UnitTest.cs
@@ -240,6 +240,20 @@ namespace Frends.File.Tests
         }
 
         [Test]
+        public void FindFilesShouldThrowIfFolderNotExist()
+        {
+            var ex = Assert.Throws<Exception>(() => File.Find(
+                new FindInput()
+                {
+                    Directory = "DoesNotExist",
+                    Pattern = "**.*"
+                },
+                new FindOption()));
+
+            Assert.That(ex.Message, Does.Contain("Directory does not exist or you do not have read access"));
+        }
+
+        [Test]
         public async Task WriteFileAppend()
         {
             TestFileContext.CreateFile("test.txt", "old content");

--- a/Frends.File/File.cs
+++ b/Frends.File/File.cs
@@ -132,6 +132,13 @@ namespace Frends.File
 
         internal static PatternMatchingResult FindMatchingFiles(string directoryPath, string pattern)
         {
+            // Check the user can access the folder
+            // This will return false if the path does not exist or you do not have read permissions.
+            if (!Directory.Exists(directoryPath))
+            {
+                throw new Exception($"Directory does not exist or you do not have read access. Tried to access directory '{directoryPath}'");
+            }
+
             var matcher = new Matcher();
             matcher.AddInclude(pattern);
             var results = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(directoryPath)));


### PR DESCRIPTION
…n exception if the directory does not exist or the user does not have read access to the directory.