### PR TITLE
Fix Frends.Tasks.Attributes reference to a working version (1.2.1)

### DIFF
--- a/Frends.File/Frends.File.csproj
+++ b/Frends.File/Frends.File.csproj
@@ -33,8 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.0\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=1.0.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.FileSystemGlobbing.1.0.1\lib\net451\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>

--- a/Frends.File/packages.config
+++ b/Frends.File/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
+  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="1.0.1" targetFramework="net452" />
   <package id="SimpleImpersonation" version="2.0.1" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -323,7 +323,6 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 Building
 ========
-Ensure that you have `https://www.myget.org/F/frends/api/v2` added to your nuget feeds
 
 Clone a copy of the repo
 

--- a/nuspec/Frends.File.nuspec
+++ b/nuspec/Frends.File.nuspec
@@ -10,7 +10,6 @@
     <description>FRENDS File tasks</description>
     <summary />
     <dependencies>
-	    <dependency id="Frends.Tasks.Attributes" version="1.2.0" />
       <dependency id="ByteSize" version="1.3.0" />
       <dependency id="Microsoft.Extensions.FileSystemGlobbing" version="[1.0.1]" />
       <dependency id="SimpleImpersonation" version="2.0.1" />
@@ -21,7 +20,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	<file src="Frends.File\bin\Release\Frends.File.dll" target="lib\net452\Frends.File.dll" />	
+	<file src="Frends.File\bin\Release\Frends.File.dll" target="lib\net452\Frends.File.dll" />
     <file src="Frends.File\bin\Release\Frends.File.XML" target="Frends.File.XML"/>
     <file src="Frends.File\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>


### PR DESCRIPTION
Version 1.2.0 cannot be used as it has the wrong assembly version, so compilation will fail.