### PR TITLE
Rename overwrite fix

### DIFF
--- a/Frends.File.Tests/CopyTest.cs
+++ b/Frends.File.Tests/CopyTest.cs
@@ -1,11 +1,9 @@
 ﻿
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.IO;
-using System.Text;
-using System.Threading.Tasks;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Frends.File.Tests
@@ -297,4 +295,3 @@ namespace Frends.File.Tests
         }
     }
 }
-

--- a/Frends.File.Tests/DisposableFileSystem.cs
+++ b/Frends.File.Tests/DisposableFileSystem.cs
@@ -22,7 +22,7 @@ namespace Frends.File.Tests
             return this;
         }
 
-        public DisposableFileSystem CreateFile(string path,string content)
+        public DisposableFileSystem CreateFile(string path, string content)
         {
             string filePath = Path.Combine(RootPath, path);
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));

--- a/Frends.File.Tests/FileTestBase.cs
+++ b/Frends.File.Tests/FileTestBase.cs
@@ -1,9 +1,5 @@
 ﻿
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Frends.File.Tests
 {

--- a/Frends.File/CopyCommand.cs
+++ b/Frends.File/CopyCommand.cs
@@ -65,11 +65,11 @@ namespace Frends.File
         /// This needs to be of format domain\username
         /// </summary>
         [DefaultValue("\"domain\\username\"")]
-        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections),"", true)]
+        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
         public string UserName { get; set; }
 
         [PasswordPropertyText]
-        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections),"", true)]
+        [UIHint(nameof(UseGivenUserCredentialsForRemoteConnections), "", true)]
         public string Password { get; set; }
 
         /// <summary>

--- a/Frends.File/Definitions.cs
+++ b/Frends.File/Definitions.cs
@@ -57,10 +57,16 @@ namespace Frends.File
     public class RenameInput
     {
         /// <summary>
-        /// Full path of the file to be renamed
+        /// Full path of the file to be renamed.
         /// </summary>
+        /// <example>C:\temp\foo.txt</example>
         [DefaultValue("\"c:\\temp\\foo.txt\"")]
         public string Path { get; set; }
+
+        /// <summary>
+        /// New filename with file extension. Final filename can differ depending on RenameOptions.RenameBehaviour and can be found from RenameResult.Path. Cannot be empty.
+        /// </summary>
+        /// <example>bar.txt</example>
         [DefaultValue("\"bar.txt\"")]
         public string NewFileName { get; set; }
     }
@@ -86,7 +92,10 @@ namespace Frends.File
         public string Password { get; set; }
 
         /// <summary>
-        /// How the file rename should work if a file with the new name already exists
+        /// How the file rename should work if a file with the new name already exists.
+        /// Throw, an error and roll back all transfers.
+        /// Overwrite, the target file.
+        /// Rename, the transferred file by appending a number to the end.
         /// </summary>
         public FileExistsAction RenameBehaviour { get; set; }
     }

--- a/Frends.File/FileBatchCommand.cs
+++ b/Frends.File/FileBatchCommand.cs
@@ -12,7 +12,7 @@ namespace Frends.File
 {
     public static class FileBatchCommand
     {
-        public static async Task<IList<FileInBatchResult>> ExecuteAsync(IFileBatchInput input, IFileBatchOptions options, 
+        public static async Task<IList<FileInBatchResult>> ExecuteAsync(IFileBatchInput input, IFileBatchOptions options,
             Func<string, string, CancellationToken, Task> batchAction, CancellationToken cancellationToken, string actionNameInErrors)
         {
             var results = File.FindMatchingFiles(input.Directory, input.Pattern);
@@ -66,7 +66,8 @@ namespace Frends.File
                     }
                     fileResults.Add(new FileInBatchResult(sourceFilePath, targetFilePath));
                 }
-            } catch(Exception)
+            }
+            catch (Exception)
             {
                 //Delete the target files that were already moved before a file that exists breaks the move command
                 Frends.File.File.DeleteExistingFiles(fileResults.Select(x => x.Path));
@@ -77,7 +78,7 @@ namespace Frends.File
         }
 
         private static void AssertNoTargetFileConflicts(IEnumerable<string> filePaths, string errorOp)
-        { 
+        {
             // check the target file list to see there should not be conflicts before doing anything
             var duplicateTargetPaths = GetDuplicateValues(filePaths);
             if (duplicateTargetPaths.Any())

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Input:
 | Property        | Type     | Description                          | Example                 |
 |-----------------|----------|--------------------------------------|-------------------------|
 | Path            | string   | Full path to the file to be renamed. | `c:\root\folder\example.txt`        |
-| NewFileName     | string   | The new filename including extension | `newName.txt`  |
+| NewFileName     | string   | New filename with file extension. Final filename can differ depending on RenameOptions.RenameBehaviour and can be found from RenameResult.Path. Cannot be empty. | `newName.txt`  |
 
 Options:
 


### PR DESCRIPTION
https://github.com/FrendsPlatform/Frends.File/issues/13

FileExistsAction.Rename will use the name given in Input.NewFileName and append a number to it.
FileExistsAction.Overwrite will overwrite the target file and delete the original file if both the original and new files match in size.
Changes how missing values are handled in ExecuteRename.