### PR TITLE
Fixed too strict Preprocessor directive

### DIFF
--- a/Frends.File/File.cs
+++ b/Frends.File/File.cs
@@ -138,7 +138,7 @@ namespace Frends.File
             }
 
             var domainAndUserName = GetDomainAndUserName(userName);
-#if NET461
+#if (NET461 || NET471)
             return await Impersonation.RunAsUser(
                             new UserCredentials(domainAndUserName[0], domainAndUserName[1], password), LogonType.NewCredentials,
                             async () => await action().ConfigureAwait(false));


### PR DESCRIPTION
Added or statement to the Preprocessor directive '#461' so that the feature could be run using framework471.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user impersonation functionality to support additional .NET Framework versions (4.7.1).
	- Improved compatibility and usability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->