### PR TITLE
Added 'Create target directories' option to Write and WriteBytes

### DIFF
--- a/Frends.File.Tests/UnitTest.cs
+++ b/Frends.File.Tests/UnitTest.cs
@@ -361,6 +361,39 @@ namespace Frends.File.Tests
             Assert.Equal("old content", fileContent);
             Assert.Equal($"File already exists: {Path.Combine(TestFileContext.RootPath, "test.txt")}", ex.Message);
         }
+        [Fact]
+        public async Task WriteFileCreateDirectory()
+        {
+            var result = await File.Write(
+                new WriteInput()
+                {
+                    Content = "Created with a subdirectory",
+                    Path = Path.Combine(TestFileContext.RootPath, "folder/Subdir/subdir.txt")
+                },
+                new WriteOption()
+                {
+                    CreateTargetDirectories = true
+                });
+            var fileContent = System.IO.File.ReadAllText(result.Path);
+            Console.WriteLine(result.Path);
+            Assert.Equal("Created with a subdirectory", fileContent);
+        }
+
+        [Fact]
+        public async Task WriteFileCreateDirectoryThrow()
+        {
+            var result = await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await File.Write(
+                new WriteInput()
+                {
+                    Content = "Task should throw",
+                    Path = Path.Combine(TestFileContext.RootPath, "folder/Subdir/subdir.txt")
+                },
+                new WriteOption()
+                {
+                    CreateTargetDirectories = false
+                }));
+            
+        }
 
         [Fact]
         public async Task WriteFileBytesAppend()
@@ -428,6 +461,42 @@ namespace Frends.File.Tests
 
             Assert.Equal(imageBytes.Length, fileContentBytes.Length);
             Assert.Equal(imageBytes, fileContentBytes);
+        }
+
+        [Fact]
+        public async Task WriteFileBytesCreateDirectory()
+        {
+            var imageBytes = System.IO.File.ReadAllBytes(BinaryTestFilePath);
+            TestFileContext.CreateBinaryFile("test.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }); // empty png
+            var result = await File.WriteBytes(
+                new WriteBytesInput()
+                {
+                    ContentBytes = imageBytes,
+                    Path = Path.Combine(TestFileContext.RootPath, "folder/Subdir/test.png")
+                },
+                new WriteBytesOption()
+                {
+                    CreateTargetDirectories = true,
+                });
+            var fileContentBytes = System.IO.File.ReadAllBytes(result.Path);
+            Assert.Equal(imageBytes.Length, fileContentBytes.Length);
+            Assert.Equal(imageBytes, fileContentBytes);
+        }
+        [Fact]
+        public async Task WriteFileBytesCreateDirectoryThrow()
+        {
+            var imageBytes = System.IO.File.ReadAllBytes(BinaryTestFilePath);
+            TestFileContext.CreateBinaryFile("test.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }); // empty png
+            var result = await Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await File.WriteBytes(
+                new WriteBytesInput()
+                {
+                    ContentBytes = imageBytes,
+                    Path = Path.Combine(TestFileContext.RootPath, "folder/Subdir/test.png")
+                },
+                new WriteBytesOption()
+                {
+                    CreateTargetDirectories = false,
+                }));
         }
 
         [Fact]

--- a/Frends.File/Definitions.cs
+++ b/Frends.File/Definitions.cs
@@ -247,6 +247,13 @@ namespace Frends.File
         /// How the file write should work if a file with the new name already exists
         /// </summary>
         public WriteBehaviour WriteBehaviour { get; set; }
+
+        /// <summary>
+        /// If set, will create the target directory if it does not exist,
+        /// as well as any sub directories.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool CreateTargetDirectories { get; set; }
     }
 
     public class WriteBytesOption
@@ -273,6 +280,13 @@ namespace Frends.File
         /// How the file write should work if a file with the new name already exists
         /// </summary>
         public WriteBehaviour WriteBehaviour { get; set; }
+
+        /// <summary>
+        /// If set, will create the target directory if it does not exist,
+        /// as well as any sub directories.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool CreateTargetDirectories { get; set; }
     }
 
     public class WriteResult

--- a/Frends.File/File.cs
+++ b/Frends.File/File.cs
@@ -287,6 +287,15 @@ namespace Frends.File
             var encoding = GetEncoding(options.FileEncoding, options.EnableBom, options.EncodingInString);
             var fileMode = GetAndCheckWriteMode(options.WriteBehaviour, input.Path);
 
+            if(options.CreateTargetDirectories)
+            {
+                var directoryPath = Path.GetDirectoryName(input.Path);
+                if(!Directory.Exists(directoryPath))
+                {
+                    Directory.CreateDirectory(directoryPath);
+                }
+            }
+
             using (var fileStream = new FileStream(input.Path, fileMode, FileAccess.Write, FileShare.Write, 4096, useAsync: true))
             using (var writer = new StreamWriter(fileStream, encoding))
             {
@@ -298,6 +307,14 @@ namespace Frends.File
 
         private static async Task<WriteResult> ExecuteWriteBytes(WriteBytesInput input, WriteBytesOption options)
         {
+            if (options.CreateTargetDirectories)
+            {
+                var directoryPath = Path.GetDirectoryName(input.Path);
+                if (!Directory.Exists(directoryPath))
+                {
+                    Directory.CreateDirectory(directoryPath);
+                }
+            }
             var bytes = input?.ContentBytes as byte[] ?? throw new ArgumentException("Input.ContentBytes must be a byte array", nameof(input.ContentBytes)); // TODO: Use corrctly typed input once UI support expression default editor for arrays
 
             var fileMode = GetAndCheckWriteMode(options.WriteBehaviour, input.Path);


### PR DESCRIPTION
Tasks Write and WriteBytes now have the option to create target directories if they do not exist removing the need to use "Create Directory".
Added tests for this new feature as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property to automatically create target directories during file writing operations.
	- Enhanced file writing methods to support automatic directory creation.

- **Bug Fixes**
	- Improved error handling for writing files to non-existent directories.

- **Tests**
	- Added four new unit tests to improve coverage for file writing functionalities involving directory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->